### PR TITLE
Add OpenSlides main repo integration requirements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Test
+on: [pull_request]
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v4
+      with:
+        go-version: '1.19'
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+
+    - name: go fmt
+      run: test -z $(gofmt -l .)
+
+    - name: go vet
+      run: go vet ./...
+
+    - name: golint
+      run: go install golang.org/x/lint/golint@latest && golint -set_exit_status ./...
+
+    - name: test
+      run: go test -timeout 30s -race ./...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+FROM golang:1.20.2-alpine as base
+WORKDIR /root/
+
+RUN apk add git
+
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY cmd cmd
+COPY pkg pkg
+
+# Build service in seperate stage.
+FROM base as builder
+RUN go build -o openslides-search-service cmd/searchd/main.go
+RUN go build -o openslides-search-generate-filter cmd/generate-filter/main.go
+
+
+# Test build.
+FROM base as testing
+
+RUN apk add build-base
+
+CMD go vet ./... && go test -test.short ./...
+
+
+# Development build.
+FROM base as development
+
+COPY --from=builder /root/openslides-search-generate-filter /root/openslides-search-generate-filter
+RUN ./openslides-search-generate-filter --output search.yml 
+RUN ["go", "install", "github.com/githubnemo/CompileDaemon@latest"]
+EXPOSE 9012
+
+RUN wget https://github.com/OpenSlides/openslides-backend/raw/main/global/meta/models.yml
+CMD CompileDaemon -log-prefix=false -build="go build -o openslides-search-service cmd/searchd/main.go" -command="./openslides-search-service"
+
+
+# Productive build
+FROM scratch
+
+LABEL org.opencontainers.image.title="OpenSlides Search Service"
+LABEL org.opencontainers.image.description="The Search Service is a http endpoint where the clients can search for data within Openslides."
+LABEL org.opencontainers.image.licenses="MIT"
+LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-search-service"
+
+COPY --from=builder /root/openslides-search-service .
+EXPOSE 9012
+ENTRYPOINT ["/openslides-search-service"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+build-dev:
+	docker build . --target development --tag openslides-search-dev
+
+run-tests:
+	docker build . --target testing --tag openslides-search-test
+	docker run openslides-search-test
+
+all: gofmt gotest golinter
+
+gotest:
+	go test ./...
+
+golinter:
+	golint -set_exit_status ./...
+
+gofmt:
+	gofmt -l -s -w .

--- a/pkg/web/http.go
+++ b/pkg/web/http.go
@@ -223,7 +223,7 @@ func Run(
 	mux := http.NewServeMux()
 
 	mux.Handle(
-		"/search",
+		"/system/search",
 		authMiddleware(http.HandlerFunc(c.search), auth))
 
 	addr := fmt.Sprintf("%s:%d", cfg.Web.Host, cfg.Web.Port)


### PR DESCRIPTION
To make this repo usable with the current OpenSlides main repo (development) setup a Makefile with at least `build-dev` and a docker image are needed. 
Also service routes which are accessible via the proxy have a `/system/{service}` prefix in their routes. 

Additionally the github workflow running linter and test used by the autoupdate service was added. 