### PR TITLE
add entrypoint script waiting for datastore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,21 +31,25 @@ FROM base as development
 RUN ["go", "install", "github.com/githubnemo/CompileDaemon@latest"]
 EXPOSE 9050
 
+COPY entrypoint.sh ./
 COPY --from=builder /root/search.yml .
 COPY --from=builder /root/models.yml .
+ENTRYPOINT ["./entrypoint.sh"]
 CMD CompileDaemon -log-prefix=false -build="go build -o openslides-search-service cmd/searchd/main.go" -command="./openslides-search-service"
 
 
 # Productive build
-FROM scratch
+FROM alpine:3
 
 LABEL org.opencontainers.image.title="OpenSlides Search Service"
 LABEL org.opencontainers.image.description="The Search Service is a http endpoint where the clients can search for data within Openslides."
 LABEL org.opencontainers.image.licenses="MIT"
 LABEL org.opencontainers.image.source="https://github.com/OpenSlides/openslides-search-service"
 
+COPY entrypoint.sh ./
 COPY --from=builder /root/search.yml .
 COPY --from=builder /root/models.yml .
 COPY --from=builder /root/openslides-search-service .
 EXPOSE 9050
-ENTRYPOINT ["/openslides-search-service"]
+ENTRYPOINT ["./entrypoint.sh"]
+CMD exec ./openslides-search-service

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT"; do
+    echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
+    sleep 1
+done
+
+echo "$DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT is available"
+
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT"; do
-    echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
-    sleep 1
-done
+if [[ $DATASTORE_WRITER_HOST && $DATASTORE_WRITER_PORT ]]; then
+    while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT"; do
+        echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
+        sleep 1
+    done
 
-echo "$DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT is available"
+    echo "$DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT is available"
+fi
 
 exec "$@"


### PR DESCRIPTION
To prevent the service from crashing because the database was not yet created by the datastore I added the entrypoint from the backend that waits for the datastore to become available. 