### PR TITLE
Use postgres key/value connection strings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,6 +8,7 @@ package config
 import (
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -140,12 +141,20 @@ func (cfg *Config) fromEnv() error {
 	})
 }
 
-// ConnectionURL returns a connection URL.
-func (db *Database) ConnectionURL() string {
-	return fmt.Sprintf("postgres://%s:%s@%s:%d/%s",
-		db.User,
-		db.Password,
-		db.Host,
+// pgEncode encodes a string to be used in the postgres key value style.
+// See: https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+func pgEncode(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `'`, `\'`)
+	return s
+}
+
+// ConnectionConfig returns a postgres Keyword/Value Connection String.
+func (db *Database) ConnectionConfig() string {
+	return fmt.Sprintf("user='%s' password='%s' host='%s' port='%d' dbname='%s'",
+		pgEncode(db.User),
+		pgEncode(db.Password),
+		pgEncode(db.Host),
 		db.Port,
-		db.Database)
+		pgEncode(db.Database))
 }

--- a/pkg/search/database.go
+++ b/pkg/search/database.go
@@ -64,7 +64,14 @@ func NewDatabase(cfg *config.Config) *Database {
 
 func (db *Database) run(fn func(context.Context, *pgx.Conn) error) error {
 	ctx := context.Background()
-	con, err := pgx.Connect(ctx, db.cfg.Database.ConnectionURL())
+	config, err := pgx.ParseConfig(db.cfg.Database.ConnectionConfig())
+	if err != nil {
+		return err
+	}
+
+	config.DefaultQueryExecMode = pgx.QueryExecModeSimpleProtocol
+
+	con, err := pgx.ConnectConfig(ctx, config)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
resolves #22 

This also switches the `DefaultQueryExecMode` to `QueryExecModeSimpleProtocol` to prevent `prepared statement already exists` errors. 