### PR TITLE
Remove exact match from wildcard

### DIFF
--- a/pkg/search/textindex.go
+++ b/pkg/search/textindex.go
@@ -405,7 +405,7 @@ func (ti *TextIndex) Search(question string, collections []string, meetingID int
 
 	wildcardQuestion := bytes.Buffer{}
 	for _, w := range strings.Split(filterExactMatchTerms(question), " ") {
-		if len(w) > 0 && w[0] != byte('*') && w[len(w)-1] != byte('*') {
+		if len(w) > 2 && w[0] != byte('*') && w[len(w)-1] != byte('*') {
 			wildcardQuestion.WriteString("*" + strings.ToLower(w) + "* ")
 		}
 	}


### PR DESCRIPTION
Words that are wrapped in `"` will no longer be added to the wildcard search query. 

This PR also adds a minimum word length of 3 for words that will be added to the wildcard query. Maybe we need to increase this further. 