### PR TITLE
Add option to not wait for DS-writer on startup

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [[ $DATASTORE_WRITER_HOST && $DATASTORE_WRITER_PORT ]]; then
+if [ ! $ANONYMOUS_ONLY -a $DATASTORE_WRITER_HOST -a $DATASTORE_WRITER_PORT ]; then
     while ! nc -z "$DATASTORE_WRITER_HOST" "$DATASTORE_WRITER_PORT"; do
         echo "waiting for $DATASTORE_WRITER_HOST:$DATASTORE_WRITER_PORT"
         sleep 1


### PR DESCRIPTION
This uses a new env var `ANONYMOUS_ONLY`.\
I am not particularly happy with this name but I chose it to be (somewhat) consistent with https://github.com/OpenSlides/openslides-autoupdate-service/pull/982.

In both cases the variable is intended to be set when setting up an OpenSlides deployment which is read-only and serving only anonymous connections.\
In this type of deployment there is no access to the backend or datastore-writer.

Also changed `[[ ... ]]` to `[ ... ]` as `#!/bin/sh` implies the script should be POSIX conform. Also I encountered weird behavior with unset and `''` variables.